### PR TITLE
Fix/song data

### DIFF
--- a/karaluxer.py
+++ b/karaluxer.py
@@ -288,7 +288,12 @@ class KaraLuxer(QDialog):
         for style in unique_styles:
             all_items = list(filter(lambda event: event.style == style, sub_data.events))
             all_items.sort(key=lambda line: line.start)
-            line_list_per_style[style] = all_items
+            line_list_per_style[style] = [event for event in all_items if isinstance(event, Comment)]
+            # In the special case where comments are not used:
+            # e.g https://kara.moe/kara/rock-over-japan/68a57800-9b23-4c62-bcc8-a77fb103b798
+            # The Dialogue is used.
+            if not line_list_per_style[style]:
+                line_list_per_style[style] = [event for event in all_items if isinstance(event, Dialogue)]
 
         return line_list_per_style, unique_styles
 

--- a/karaluxer.py
+++ b/karaluxer.py
@@ -27,7 +27,7 @@ CommentList = List[_Event]
 # ----------------------------
 
 # Regex to extract timing information from a line.
-TIMING_REGEX = re.compile(r'(\{\\(?:k|kf|ko|K)[0-9.]+\}[a-zA-Z _.\-,!"\']+\s*)|({\\(?:k|kf|ko|K)[0-9.]+[^}]*\})')
+TIMING_REGEX = re.compile(r'(\{\\(?:k|kf|ko|K)[0-9.]+\}[A-zÀ-ÿ _.\-,!"\']+\s*)|({\\(?:k|kf|ko|K)[0-9.]+[^}]*\})')
 
 # Regex to check a kara.moe url is valid.
 KARA_URL_REGEX = re.compile(r'https:\/\/kara\.moe\/kara\/[\w-]+\/[\w-]+')


### PR DESCRIPTION
In my previous PR i removed the Comment/Dialog if statements.

They're now back in as without it users might see double lines as shown here: https://kara.moe/downloads/lyrics/JPN%20-%20Pokemon%20Kimi%20ni%20Kimeta!%20-%20MOVIE%20OP%20-%20Mezase%20Pokemon%20Master%20-20th%20Anniversary-.ass

This reverts that.

Also within #1 an issue is mentioned about special characters. This has been resolved by allowing more special characters within the `TIMING_REGEX`. We now allow:
* accepts lowercase and uppercase characters including diacritics
* And letters with the ümlaut