### PR TITLE
Fix tweaked_duration bug

### DIFF
--- a/karaluxer.py
+++ b/karaluxer.py
@@ -354,9 +354,9 @@ class KaraLuxer():
                     current_beat += converted_duration
                     continue
 
-                    # Notes should be slightly shorter than their original duration, to make it easier to sing.
-                    # Currently this is done by simply reducing the duration by one. This could use improvement.
-                    tweaked_duration = converted_duration - 1 if converted_duration > 1 else converted_duration
+                # Notes should be slightly shorter than their original duration, to make it easier to sing.
+                # Currently this is done by simply reducing the duration by one. This could use improvement.
+                tweaked_duration = converted_duration - 1 if converted_duration > 1 else converted_duration
 
                 self.ultrastar_song.add_note(
                     ':',


### PR DESCRIPTION
**Description of work**

Currently, KaraLuxer crashes during the conversion of any song due to this error:
```
Traceback (most recent call last):
  File "kl_gui.py", line 100, in run
  File "karaluxer.py", line 580, in run
  File "karaluxer.py", line 364, in _convert_lines
UnboundLocalError: local variable 'tweaked_duration' referenced before assignment
```

This has been fixed by changing the indentation in `karaluxer.py` so that `tweaked_duration` gets always set.


**To test**

1. Download the build from this branch
2. Convert a song