### PR TITLE
Add BPM option

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -51,7 +51,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo sed -i '' 's|tools/ffmpeg.exe|/usr/local/Cellar/ffmpeg/6.0_2/bin/ffmpeg|' kl_gui.spec
+          sudo sed -i '' 's|tools/ffmpeg.exe|ffmpeg|' kl_gui.spec
+          
           sudo sed -i '' 's|tools/|/Users/runner/hostedtoolcache/Python/3.10.9/x64/lib/python3.10/site-packages/ultrastar_pitch/binaries/|' kl_gui.spec
           sudo sed -i '' 's|.venv/lib/|/Users/runner/hostedtoolcache/Python/3.10.9/x64/lib/python3.10/|' kl_gui.spec
           

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -6,7 +6,7 @@ jobs:
   windows:
     runs-on: windows-latest
     steps:
-      - uses: FedericoCarboni/setup-ffmpeg@v1
+      - uses: FedericoCarboni/setup-ffmpeg@v3
         id: setup-ffmpeg
 
       - uses: actions/checkout@v3
@@ -23,7 +23,7 @@ jobs:
 
       - name: Create bundle
         run: |
-          (gc kl_gui.spec) -replace 'tools/ffmpeg.exe', 'C:/hostedtoolcache/windows/ffmpeg/5.0.1/x64/ffmpeg.exe' | Out-File -encoding UTF8 kl_gui.spec
+          (gc kl_gui.spec) -replace 'tools/ffmpeg.exe', ${{steps.setup-ffmpeg.ffmpeg-path}} | Out-File -encoding UTF8 kl_gui.spec
           (gc kl_gui.spec) -replace 'tools/', 'C:/hostedtoolcache/windows/Python/3.10.9/x64/Lib/site-packages/ultrastar_pitch/binaries/' | Out-File -encoding UTF8 kl_gui.spec
           (gc kl_gui.spec) -replace '.venv/', 'C:/hostedtoolcache/windows/Python/3.10.9/x64/' | Out-File -encoding UTF8 kl_gui.spec
           pyinstaller kl_gui.spec
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install ffmpeg
-        run: brew install ffmpeg
+        run: brew install ffmpeg@6.1.1
 
       - name: Install python
         uses: actions/setup-python@v4
@@ -51,7 +51,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo sed -i '' 's|tools/ffmpeg.exe|/usr/local/Cellar/ffmpeg/5.1.2_1/bin/ffmpeg|' kl_gui.spec
+          sudo sed -i '' 's|tools/ffmpeg.exe|/usr/local/Cellar/ffmpeg/6.1.1_3/bin/ffmpeg|' kl_gui.spec
           sudo sed -i '' 's|tools/|/Users/runner/hostedtoolcache/Python/3.10.9/x64/lib/python3.10/site-packages/ultrastar_pitch/binaries/|' kl_gui.spec
           sudo sed -i '' 's|.venv/lib/|/Users/runner/hostedtoolcache/Python/3.10.9/x64/lib/python3.10/|' kl_gui.spec
           

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Create bundle
         run: |
-          (gc kl_gui.spec) -replace 'tools/ffmpeg.exe', ${{steps.setup-ffmpeg.ffmpeg-path}} | Out-File -encoding UTF8 kl_gui.spec
+          (gc kl_gui.spec) -replace 'tools/ffmpeg.exe', "${{steps.setup-ffmpeg.ffmpeg-path}}" | Out-File -encoding UTF8 kl_gui.spec
           (gc kl_gui.spec) -replace 'tools/', 'C:/hostedtoolcache/windows/Python/3.10.9/x64/Lib/site-packages/ultrastar_pitch/binaries/' | Out-File -encoding UTF8 kl_gui.spec
           (gc kl_gui.spec) -replace '.venv/', 'C:/hostedtoolcache/windows/Python/3.10.9/x64/' | Out-File -encoding UTF8 kl_gui.spec
           pyinstaller kl_gui.spec
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install ffmpeg
-        run: brew install ffmpeg@6.1.1
+        run: brew install ffmpeg@6
 
       - name: Install python
         uses: actions/setup-python@v4

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -51,8 +51,10 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo sed -i '' 's|tools/ffmpeg.exe|ffmpeg|' kl_gui.spec
-          
+          test -f "/usr/local/Cellar/ffmpeg/6.0_2/bin/ffmpeg" && sudo sed -i '' 's|tools/ffmpeg.exe|/usr/local/Cellar/ffmpeg/6.0_2/bin/ffmpeg|' kl_gui.spec
+          test -f "/usr/local/Cellar/ffmpeg/6.1.1_2/bin/ffmpeg" && sudo sed -i '' 's|tools/ffmpeg.exe|/usr/local/Cellar/ffmpeg/6.1.1_2/bin/ffmpeg|' kl_gui.spec
+          test -f "/usr/local/Cellar/ffmpeg/6.1.1_3/bin/ffmpeg" && sudo sed -i '' 's|tools/ffmpeg.exe|/usr/local/Cellar/ffmpeg/6.1.1_3/bin/ffmpeg|' kl_gui.spec
+
           sudo sed -i '' 's|tools/|/Users/runner/hostedtoolcache/Python/3.10.9/x64/lib/python3.10/site-packages/ultrastar_pitch/binaries/|' kl_gui.spec
           sudo sed -i '' 's|.venv/lib/|/Users/runner/hostedtoolcache/Python/3.10.9/x64/lib/python3.10/|' kl_gui.spec
           

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo sed -i '' 's|tools/ffmpeg.exe|/usr/local/Cellar/ffmpeg/6.1.1_3/bin/ffmpeg|' kl_gui.spec
+          sudo sed -i '' 's|tools/ffmpeg.exe|/usr/local/Cellar/ffmpeg/6.0_2/bin/ffmpeg|' kl_gui.spec
           sudo sed -i '' 's|tools/|/Users/runner/hostedtoolcache/Python/3.10.9/x64/lib/python3.10/site-packages/ultrastar_pitch/binaries/|' kl_gui.spec
           sudo sed -i '' 's|.venv/lib/|/Users/runner/hostedtoolcache/Python/3.10.9/x64/lib/python3.10/|' kl_gui.spec
           

--- a/kl_gui.py
+++ b/kl_gui.py
@@ -291,10 +291,16 @@ class KaraLuxerWindow(QDialog):
         audio_button.clicked.connect(lambda: self._get_file_path(self.audio_input, "Audio files (*.mp3)"))
         optional_args_layout.addWidget(audio_button, 2, 2)
 
+        self.bpm = QLineEdit()
+        self.bpm.setPlaceholderText('Default is 1500.')
+        optional_args_layout.addWidget(QLabel('BPM:'), 3, 0)
+        optional_args_layout.addWidget(self.bpm, 3, 1)
+        optional_args_layout.addWidget(QLabel('For easier mapping and singing'), 3, 2)
+
         self.tv_checkbox = QCheckBox()
-        optional_args_layout.addWidget(QLabel('TV Sized:'), 3, 0)
-        optional_args_layout.addWidget(self.tv_checkbox, 3, 1)
-        optional_args_layout.addWidget(QLabel('Appends "(TV)" to the song title'), 3, 2)
+        optional_args_layout.addWidget(QLabel('TV Sized:'), 4, 0)
+        optional_args_layout.addWidget(self.tv_checkbox, 4, 1)
+        optional_args_layout.addWidget(QLabel('Appends "(TV)" to the song title'), 4, 2)
 
         optional_args_group.setLayout(optional_args_layout)
 
@@ -496,6 +502,13 @@ class KaraLuxerWindow(QDialog):
         audio_file = self.audio_input.text() if self.audio_input.text() else None
         tv_sized = self.tv_checkbox.isChecked()
 
+        try:
+            bpm = float(self.bpm.text()) if self.bpm.text() else 1500
+        except ValueError:
+            self._display_message(f'BPM must be a number, but "{self.bpm.text()}" was provided.', self.LVL_ERROR)
+            self._indicator_bar_stop()
+            return
+
         overlap_filter_mode = None
         overlap_filter_mode = "style" if self.style_overlaps_checkbox.isChecked() else overlap_filter_mode
         overlap_filter_mode = "individual" if self.individual_overlaps_checkbox.isChecked() else overlap_filter_mode
@@ -515,7 +528,8 @@ class KaraLuxerWindow(QDialog):
                 overlap_filter_mode,
                 force_dialogue,
                 tv_sized,
-                generate_pitches
+                generate_pitches,
+                bpm
             )
         except (ValueError, IOError) as e:
             self._display_message(str(e), self.LVL_ERROR)


### PR DESCRIPTION
**Description**

It is generally easier to both map a song and sing it when the BPM is a small multiple of the true BPM; most songs (that I have encountered anyway) have a true BPM of around 100, and a typical value of ultrastar maps is around 300. However, KaraLuxer uses a BPM of 1500 so that no rounding has to occur in the conversion from kara.moe .ass to Ultrastar .txt, with no option to change this. The BPM has to be changed later manually if it is desired, and most people who are not dedicated to quality likely do not know how to do this easily (even I didn't do this until recently). Therefore, I have added a new field to the GUI as well as a new option to the script that allows users to specify the BPM the final song should be. The final song will have the specified BPM with all the timings and lengths correctly adjusted.

Additionally, while I was at it, I updated the CI/CD so that it works again (and hopefully it will be more resilient in the future to new ffmpeg versions).