### PR TITLE
BUG: Fix the new BPM option to adjust the BPM of linebreaks

### DIFF
--- a/karaluxer.py
+++ b/karaluxer.py
@@ -376,7 +376,7 @@ class KaraLuxer():
                 current_beat += converted_duration
 
             # Write a linebreak at the end of the line.
-            self.ultrastar_song.add_note('-', current_beat)
+            self.ultrastar_song.add_note('-', int(round(current_beat * self.bpm / KARALUXER_BPM)))
 
     def _fetch_kara_data(self, kara_id: str) -> Dict[str, str]:
         """Fetches relevant data about a map using the Kara api.


### PR DESCRIPTION
**Description**

As I was mapping new songs using the new BPM functionality I added in #10, I noticed that the linebreaks (the e.g. `- 10` lines) were not being properly converted to the set BPM and were instead staying as very large numbers. Looking into the code, I noticed that I previously forgot to change the part that adds the linebreaks so that it correctly adjusts the BPM the same way the notes are adjusted. This PR should fix that, meaning the BPM functionality should now work properly, converting the BPM of both the notes and the linebreaks.

I am sorry about the mistake; I had not tested the changes properly.