### PR TITLE
Add year and anime metadata to generated karaoke files

### DIFF
--- a/karaluxer.py
+++ b/karaluxer.py
@@ -406,13 +406,13 @@ class KaraLuxer():
         artist_data = data['singergroups'] if data['singergroups'] else data['singers']
         artists = ''
         for singer in artist_data:
-            artists += singer['name'] + ' & '
+            artists += singer['name'] + ', '
         kara_data['artists'] = artists[:-3]
 
         # Get map authors
         authors = ''
         for author in data['authors']:
-            authors += author['name'] + ' & '
+            authors += author['name'] + ', '
         kara_data['authors'] = authors[:-3]
 
         anime = []

--- a/karaluxer.py
+++ b/karaluxer.py
@@ -398,7 +398,8 @@ class KaraLuxer():
             'title': data['titles'][data['titles_default_language']],
             'sub_file': data['subfile'],
             'media_file': data['mediafile'],
-            'language': data['langs'][0]['i18n']['eng']
+            'language': data['langs'][0]['i18n']['eng'],
+            'year': data['year']
         }
 
         # Get song artists. Prioritizes "singergroups" (band) field when present.
@@ -413,6 +414,33 @@ class KaraLuxer():
         for author in data['authors']:
             authors += author['name'] + ' & '
         kara_data['authors'] = authors[:-3]
+
+        anime = []
+        for series in data['series']:
+            name = series['name'].replace(',', '')  # Default name
+
+            try:
+                anime.append(series['i18n']['eng'].replace(',', ''))
+
+                # Only add the default name if it is different from the English name
+                if anime[-1] != name:
+                    anime.append(name)
+            except KeyError:
+                anime.append(name)
+
+            if series['aliases']:
+                for alias in series['aliases']:
+                    anime.append(alias.replace(',', ''))
+
+        song_types = []
+        for song_type in data['songtypes']:
+            try:
+                song_types.append(song_type['i18n']['eng'])
+            except KeyError:
+                pass
+
+        tags = ', '.join([', '.join(anime), ', '.join(song_types)])
+        kara_data['tags'] = tags
 
         return kara_data
 
@@ -488,6 +516,9 @@ class KaraLuxer():
             self.ultrastar_song.add_metadata('ARTIST', kara_data['artists'])
             self.ultrastar_song.add_metadata('CREATOR', kara_data['authors'])
             self.ultrastar_song.add_metadata('LANGUAGE', kara_data['language'])
+            self.ultrastar_song.add_metadata('YEAR', kara_data['year'])
+            if kara_data['tags']:
+                self.ultrastar_song.add_metadata('TAGS', kara_data['tags'])
 
             temporary_folder = Path('tmp')
 

--- a/karaluxer.py
+++ b/karaluxer.py
@@ -519,6 +519,7 @@ class KaraLuxer():
             self.ultrastar_song.add_metadata('YEAR', kara_data['year'])
             if kara_data['tags']:
                 self.ultrastar_song.add_metadata('TAGS', kara_data['tags'])
+            self.ultrastar_song.add_metadata('VERSION', '1.1.0')
 
             temporary_folder = Path('tmp')
 


### PR DESCRIPTION
**Description**

I have noticed that KaraLuxer output is missing some potentially useful metadata. Firstly, the year information is available from [kara.moe](https://kara.moe/) API and can be useful for searchin and filtering withn Vocaluxe, but it was not saved into the output karaoke. Secondly, the anime. I know this was a bit of a complex topic, but the latest version of the [ultrastar file format spec](https://usdx.eu/format/) has added the new #TAGS attribute which I believe is a great place to put anime information. Therefore, this PR places the English and Japanese names of the anime as well as any alieses from kara.moe to the #TAGS attribute.

Additionally, the new and mandatory #VERSION  attribute has been implemented and set to 1.1.0, the latest version of the spec. Further, the separator for creators and artists has been changed from `&` to `,` since that is how the spec is now defined.

**To Test**

1. Run the KaraLuxer on a kara.moe map of choice
2. The created karaoke should contain the year metadata under #YEAR, anime metadata under #TAGS, a #VERSION tag, and any creators and artists should be separated by commas within the file (but the filenames should not contain the commas).