### PR TITLE
Fix last character missing from artist and creator

### DIFF
--- a/karaluxer.py
+++ b/karaluxer.py
@@ -404,16 +404,10 @@ class KaraLuxer():
 
         # Get song artists. Prioritizes "singergroups" (band) field when present.
         artist_data = data['singergroups'] if data['singergroups'] else data['singers']
-        artists = ''
-        for singer in artist_data:
-            artists += singer['name'] + ', '
-        kara_data['artists'] = artists[:-3]
+        kara_data['artists'] = ', '.join([singer['name'] for singer in artist_data])
 
         # Get map authors
-        authors = ''
-        for author in data['authors']:
-            authors += author['name'] + ', '
-        kara_data['authors'] = authors[:-3]
+        kara_data['authors'] = ', '.join([author['name'] for author in data['authors']])
 
         anime = []
         for series in data['series']:


### PR DESCRIPTION
**Description**

Using KaraLuxer, I've noticed that after the latest PRs I submitted, the last character from the artist name as well as the creator name were missing (this included both the ultrastar-format .txt file and the file and folder names). This was due to the change in the separator used and has been fixed in this PR.

**To Test**

1. Use KaraLuxer as normal
2. Check that all the # fields in the txt file, especially #ARTIST and #CREATOR are correct.