### PR TITLE
Add automatic audio normalisation to highest volume

### DIFF
--- a/karaluxer.py
+++ b/karaluxer.py
@@ -545,7 +545,9 @@ class KaraLuxer():
                     env_variables = os.environ.copy()
                     env_variables['FFMPEG_PATH'] = str(FFMPEG_PATH)
                     ret_val = subprocess.run(['ffmpeg-normalize', str(media_path), '-c:a', 'libmp3lame', '-b:a', '320k',
-                                              '-t', '-5', '-vn', '-sn', '-o', f'{os.path.abspath(audio_path)}'],
+                                              '-t', '-5', '-vn', '-sn', '-lrt', '50',
+                                              '--keep-lra-above-loudness-range-target',
+                                              '-o', f'{os.path.abspath(audio_path)}'],
                                              env=env_variables)
                     if ret_val.returncode:
                         print('WARNING: Audio volume normalisation failed.')

--- a/kl_gui.py
+++ b/kl_gui.py
@@ -363,6 +363,14 @@ class KaraLuxerWindow(QDialog):
         advanced_args_layout.addWidget(self.autopitch_checkbox, 1, 1)
         advanced_args_layout.addWidget(QLabel('Will pitch the file using "ultrastar_pitch"'), 1, 2)
 
+        self.normalise_checkbox = QCheckBox()
+        advanced_args_layout.addWidget(QLabel('Normalise audio:'), 2, 0)
+        advanced_args_layout.addWidget(self.normalise_checkbox, 2, 1)
+        advanced_args_layout.addWidget(
+            QLabel('When the Kara.moe source contains a low-volume video file, will enable loudness normalisation '
+                   'during audio extraction.'), 2, 2)
+        self.normalise_checkbox.setChecked(True)
+
         advanced_args_group.setLayout(advanced_args_layout)
 
         # Progress indicator
@@ -516,6 +524,7 @@ class KaraLuxerWindow(QDialog):
 
         force_dialogue = self.force_dialogue_checkbox.isChecked()
         generate_pitches = self.autopitch_checkbox.isChecked()
+        enable_normalisation = self.normalise_checkbox.isChecked()
 
         try:
             karaluxer_instance = KaraLuxer(
@@ -529,7 +538,8 @@ class KaraLuxerWindow(QDialog):
                 force_dialogue,
                 tv_sized,
                 generate_pitches,
-                bpm
+                bpm,
+                enable_normalisation
             )
         except (ValueError, IOError) as e:
             self._display_message(str(e), self.LVL_ERROR)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ requests==2.28.1
 ultrastar-pitch==1.0.1
 PyQt5-Qt5==5.15.2
 pyinstaller==5.4.1
+ffmpeg-normalize==1.27.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ requests==2.28.1
 ultrastar-pitch==1.0.1
 PyQt5-Qt5==5.15.2
 pyinstaller==5.4.1
-ffmpeg-normalize==1.27.1


### PR DESCRIPTION
**Description**

The karaoke library has a massive variation in the volumes of different songs, which is not only annoying when the speaker volume has to be constantly readjusted, but it also makes the quietest songs difficult to hear and sing. Therefore, this PR introduces automatic volume normalisation using the ffmpeg's inbuilt peak-based audio normaliser (via `-filter:a "volume=0dB"`). However, this is only used when the kara.moe map consists of video instead of audio since in that case the audio is already being re-encoded and therefore adding volume normalisation at the same time should not introduce any additional compression artifacts. The normalisation does not take place in the case when the kara.moe map contains audio and not video to avoid compression artifacts, but we can discuss this.

The normalisation is set to be to the highest reasonable volume (i.e. highest volume that does not degrade audio quality) to avoid having too quiet songs; from my experience it is always easier to turn volume down than up during karaoke. If the song is already loud, no change takes place.

Lastly, a checkbox has been added to KaraLuxer GUI that allows users to disable this feature.

**To test**

1. Convert a kara.moe map using this version of KaraLuxer
2. See that the volume in .mp3 is louder than that in .mp4.
3. (optional) use the `ffmpeg -i a.mp3 -af "volumedetect" -vn -sn -dn -f null -` command and see that the max volume is close to 0.