### PR TITLE
Add ability to set specific BPM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ venv/
 
 # VSCode files
 .vscode/
+# PyCharm files
+.idea
 
 # Python cache files
 __pycache__/

--- a/karaluxer.py
+++ b/karaluxer.py
@@ -62,8 +62,8 @@ class KaraLuxer():
         force_dialogue_lines: bool = False,
         tv_sized: bool = False,
         autopitch: bool = False,
-        bpm: float = 1500,
-        bpm_multiplier: int = 1
+        karaoke_bpm: float = 1500,
+        song_bpm: float = 1500
     ) -> None:
         """Sets up the KaraLuxer instance.
 
@@ -88,11 +88,11 @@ class KaraLuxer():
             tv_sized (bool, optional): If True will append (TV) to the song title. (This is the convention that
                 ultrastar.es uses).
             autopitch (bool, optional): If True Karaluxer will attempt to use ultrastar_pitch to pitch the notes.
-            bpm (float, optional): The BPM (beats per minute) of the song that will be used instead of the default 1500
-                BPM. For ultrastar maps, this tends to be approximately 300, even if the true BPM is often much lower.
-            bpm_multiplier (int, optional): The BPM multiplier, or the multiplier of the karaoke BPM with respect to
-                the true BPM. In other words: $\frac{karaoke BPM}{true BPM}$. Having the karaoke BPM a 3 or 4 multiple
-                of the true BPM allows for easier creation of gaps in between notes. Providing this option will allow
+            karaoke_bpm (float, optional): The BPM (beats per minute) for the karaoke txt file that will be used instead
+                of the default 1500 BPM. For ultrastar maps, this tends to be approximately 300, even if the true BPM
+                is often much lower.
+            song_bpm (float, optional): The actual BPM of the song/audio. Having the karaoke BPM a 3 or 4 multiple
+                of the Song BPM allows for easier creation of gaps in between notes. Providing this option will allow
                 KaraLuxer to arrange the notes more closely to the correct timing.
         """
 
@@ -112,8 +112,15 @@ class KaraLuxer():
         self.force_dialogue_lines = force_dialogue_lines
         self.tv_sized = tv_sized
         self.autopitch = autopitch
-        self.bpm = bpm
-        self.bpm_multiplier = bpm_multiplier
+        self.bpm = karaoke_bpm
+
+        self.bpm_multiplier = karaoke_bpm / song_bpm
+        if self.bpm_multiplier % 1 < 1e-5:
+            self.bpm_multiplier = int(self.bpm_multiplier)
+        else:
+            raise ValueError('The Karaoke BPM must be an integer multiple of the Song BPM (provided multiple='
+                             f'{self.bpm_multiplier}). Either provide a valid combination of Karaoke and Song BPM or '
+                             f'do not set the Song BPM.')
 
         # Parameter checks
         if kara_url and not re.match(r'https:\/\/kara\.moe\/kara\/[\w-]+\/[\w-]+', kara_url):
@@ -686,12 +693,14 @@ def main() -> None:
     argument_parser.add_argument('-tv', '--tv_sized', action='store_true', help='Mark this song as TV sized.')
     argument_parser.add_argument('-ap', '--autopitch',
                                  action='store_true', help='Pitch the song using ultrastar_pitch.')
-    argument_parser.add_argument('--bpm', type=float, default=1500.,
-                                 help='The BPM of the song. If not provided, 1500 will be used as default.')
-    argument_parser.add_argument('--bpm-multiplier', type=int, default=1,
-                                 help='The integer by which the true song BPM was multiplied to obtain the provided '
-                                      '(the "--bpm" option) karaoke BPM. If provided, this multiplier is used to '
-                                      'remove overlaps and otherwise clean up the timings to make mapping easier.')
+    argument_parser.add_argument('--karaoke-bpm', type=float, default=1500.,
+                                 help='The Karaoke BPM, i.e. the BPM that will be used in the karaoke txt file. '
+                                      'If not provided, 1500 will be used as default.')
+    argument_parser.add_argument('--song-bpm', type=int, default=0,
+                                 help='The true Song BPM, i.e. the BPM of the song. This should be different from the '
+                                      'Karaoke BPM; Karaoke BPM has to be an integer multiple of the Song BPM. '
+                                      'If provided, this is used to calculate the multiple which is used to remove '
+                                      'overlaps and otherwise clean up the timings to make mapping easier.')
 
     argument_parser.set_defaults(ignore_overlaps=False, force_dialogue=False, tv_sized=False, autopitch=False)
 
@@ -708,8 +717,8 @@ def main() -> None:
         arguments.force_dialogue,
         arguments.tv_sized,
         arguments.autopitch,
-        arguments.bpm,
-        arguments.bpm_multiplier
+        arguments.karaoke_bpm,
+        arguments.song_bpm if arguments.song_bpm != 0 else arguments.karaoke_bpm
     )
 
     def cli_overlap_decision_function(overlapping_lines: List[ass.line._Event]) -> ass.line._Event:

--- a/kl_gui.py
+++ b/kl_gui.py
@@ -293,9 +293,11 @@ class KaraLuxerWindow(QDialog):
 
         self.bpm = QLineEdit()
         self.bpm.setPlaceholderText('Default is 1500.')
+        self.bpm_multiplier = QLineEdit()
+        self.bpm_multiplier.setPlaceholderText('Multiplier')
         optional_args_layout.addWidget(QLabel('BPM:'), 3, 0)
         optional_args_layout.addWidget(self.bpm, 3, 1)
-        optional_args_layout.addWidget(QLabel('For easier mapping and singing'), 3, 2)
+        optional_args_layout.addWidget(self.bpm_multiplier, 3, 2)
 
         self.tv_checkbox = QCheckBox()
         optional_args_layout.addWidget(QLabel('TV Sized:'), 4, 0)
@@ -509,6 +511,14 @@ class KaraLuxerWindow(QDialog):
             self._indicator_bar_stop()
             return
 
+        try:
+            bpm_multiplier = int(self.bpm_multiplier.text()) if self.bpm_multiplier.text() else 1
+        except ValueError:
+            self._display_message(f'The BPM multipliear must be an integer, but "{self.bpm.text()}" was provided.',
+                                  self.LVL_ERROR)
+            self._indicator_bar_stop()
+            return
+
         overlap_filter_mode = None
         overlap_filter_mode = "style" if self.style_overlaps_checkbox.isChecked() else overlap_filter_mode
         overlap_filter_mode = "individual" if self.individual_overlaps_checkbox.isChecked() else overlap_filter_mode
@@ -529,7 +539,8 @@ class KaraLuxerWindow(QDialog):
                 force_dialogue,
                 tv_sized,
                 generate_pitches,
-                bpm
+                bpm,
+                bpm_multiplier
             )
         except (ValueError, IOError) as e:
             self._display_message(str(e), self.LVL_ERROR)

--- a/kl_gui.py
+++ b/kl_gui.py
@@ -291,13 +291,13 @@ class KaraLuxerWindow(QDialog):
         audio_button.clicked.connect(lambda: self._get_file_path(self.audio_input, "Audio files (*.mp3)"))
         optional_args_layout.addWidget(audio_button, 2, 2)
 
-        self.bpm = QLineEdit()
-        self.bpm.setPlaceholderText('Default is 1500.')
-        self.bpm_multiplier = QLineEdit()
-        self.bpm_multiplier.setPlaceholderText('Multiplier')
+        self.karaoke_bpm = QLineEdit()
+        self.karaoke_bpm.setPlaceholderText('Karaoke BPM. Default is 1500.')
+        self.song_bpm = QLineEdit()
+        self.song_bpm.setPlaceholderText('Song BPM. (optional)')
         optional_args_layout.addWidget(QLabel('BPM:'), 3, 0)
-        optional_args_layout.addWidget(self.bpm, 3, 1)
-        optional_args_layout.addWidget(self.bpm_multiplier, 3, 2)
+        optional_args_layout.addWidget(self.karaoke_bpm, 3, 1)
+        optional_args_layout.addWidget(self.song_bpm, 3, 2)
 
         self.tv_checkbox = QCheckBox()
         optional_args_layout.addWidget(QLabel('TV Sized:'), 4, 0)
@@ -505,16 +505,16 @@ class KaraLuxerWindow(QDialog):
         tv_sized = self.tv_checkbox.isChecked()
 
         try:
-            bpm = float(self.bpm.text()) if self.bpm.text() else 1500
+            karaoke_bpm = float(self.karaoke_bpm.text()) if self.karaoke_bpm.text() else 1500
         except ValueError:
-            self._display_message(f'BPM must be a number, but "{self.bpm.text()}" was provided.', self.LVL_ERROR)
+            self._display_message(f'BPM must be a number, but "{self.karaoke_bpm.text()}" was provided.', self.LVL_ERROR)
             self._indicator_bar_stop()
             return
 
         try:
-            bpm_multiplier = int(self.bpm_multiplier.text()) if self.bpm_multiplier.text() else 1
+            song_bpm = float(self.song_bpm.text()) if self.song_bpm.text() else karaoke_bpm
         except ValueError:
-            self._display_message(f'The BPM multipliear must be an integer, but "{self.bpm.text()}" was provided.',
+            self._display_message(f'The Song BPM must be a number, but "{self.karaoke_bpm.text()}" was provided.',
                                   self.LVL_ERROR)
             self._indicator_bar_stop()
             return
@@ -539,8 +539,8 @@ class KaraLuxerWindow(QDialog):
                 force_dialogue,
                 tv_sized,
                 generate_pitches,
-                bpm,
-                bpm_multiplier
+                karaoke_bpm,
+                song_bpm
             )
         except (ValueError, IOError) as e:
             self._display_message(str(e), self.LVL_ERROR)

--- a/ultrastar/ultrastar.py
+++ b/ultrastar/ultrastar.py
@@ -103,6 +103,55 @@ class UltrastarSong():
         note = NoteLine(note_type, start_beat, duration, pitch, text)
         self.note_lines[player].append(note)
 
+    def adjust_notes(
+        self,
+        bpm_multiplier: int,
+        player: str = 'P1'
+    ) -> None:
+        notes = self.note_lines[player]
+        for i, note in enumerate(notes):
+            if note.note_type != '-':
+                start = i
+                break
+        else:
+            return
+
+        start_beat = notes[start].start_beat
+
+        if notes[start].duration < bpm_multiplier:
+            notes[start].duration = bpm_multiplier
+        else:
+            notes[start].duration = bpm_multiplier * round(notes[start].duration / bpm_multiplier)
+
+        for i, note in enumerate(notes[start+1:]):
+            for previous_note in notes[start+i::-1]:
+                if previous_note.note_type != '-':
+                    break
+            else:
+                continue
+
+            previous_note_end = previous_note.start_beat + previous_note.duration
+
+            if note.note_type == '-':
+                if note.start_beat < previous_note_end:
+                    note.start_beat = previous_note_end
+                continue
+
+            if note.start_beat < previous_note_end:
+                note.start_beat = previous_note_end
+            else:
+                modulus = (note.start_beat - start_beat) % bpm_multiplier
+                if modulus != 0:
+                    if round(modulus / bpm_multiplier) == 1:
+                        note.start_beat += bpm_multiplier - modulus
+                    else:
+                        note.start_beat -= modulus
+
+            if note.duration < bpm_multiplier:
+                note.duration = bpm_multiplier
+            else:
+                note.duration = bpm_multiplier * round(note.duration / bpm_multiplier)
+
     def __str__(self) -> str:
         """Produces a string representation of the song.
 

--- a/ultrastar/ultrastar.py
+++ b/ultrastar/ultrastar.py
@@ -137,7 +137,8 @@ class UltrastarSong():
                     note.start_beat = previous_note_end
                 continue
 
-            if note.start_beat < previous_note_end:
+            if previous_note_end > note.start_beat > previous_note_end - bpm_multiplier:
+                # If notes are overlapping due to the BPM change rather than because there is an overlap
                 note.start_beat = previous_note_end
             else:
                 modulus = (note.start_beat - start_beat) % bpm_multiplier


### PR DESCRIPTION
**Description**

Builds on #10. A new optional field has been added to GUI (next to the previous (*karaoke*) BPM field) and a new optional argument has been added to CLI, which allow users to specify the *song* BPM, i.e. the true BPM of the audio file. If provided, this is used to adjust all the notes such that they are of a length that is an integer multiple of the karaoke BPM, which should make the mapping easier if the OG singer sung the song accurately and precisely. This is because in most songs, to keep the rythm (or is it melod?), notes and breaks are usually evenly spaced. However, this option may cause some incorrect shifting, especially if the inputted BPM is off, or if the singer is off by a fraction of a beat, or if the kara.moe map is a bit off.

**To test**

1. Map a song by inputting both of the BPM fields correctly. The #BPM field should be  the inputted karaoke BPM, and all notes should have a length that is a multiple of the karaoke BPM.