### PR TITLE
Update the CI/CD pipeline

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -27,9 +27,9 @@ jobs:
 
       - name: Create bundle
         run: |
-          echo "${{steps.setup-ffmpeg.ffmpeg-path}}"
+          echo "${{steps.setup-ffmpeg.outputs.ffmpeg-path}}"
           echo "should have been displayed above"
-          (gc kl_gui.spec) -replace 'tools/ffmpeg.exe', "${{steps.setup-ffmpeg.ffmpeg-path}}" | Out-File -encoding UTF8 kl_gui.spec
+          (gc kl_gui.spec) -replace 'tools/ffmpeg.exe', "${{steps.setup-ffmpeg.outputs.ffmpeg-path}}" | Out-File -encoding UTF8 kl_gui.spec
           (gc kl_gui.spec) -replace 'tools/', "C:/hostedtoolcache/windows/Python/${{env.PYTHON_VERSION}}/x64/Lib/site-packages/ultrastar_pitch/binaries/" | Out-File -encoding UTF8 kl_gui.spec
           (gc kl_gui.spec) -replace '.venv/', "C:/hostedtoolcache/windows/Python/${{env.PYTHON_VERSION}}/x64/" | Out-File -encoding UTF8 kl_gui.spec
           pyinstaller kl_gui.spec
@@ -48,10 +48,10 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install ffmpeg
-        run: brew install ffmpeg@6
+        run: brew install ffmpeg@7
 
       - name: find ffmpeg
-        run: brew info ffmpeg
+        run: brew info ffmpeg@7
 
       - name: Install python
         uses: actions/setup-python@v4

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -3,8 +3,8 @@ name: CI/CD
 on: [push, workflow_dispatch]
 
 env:
-  PYTHON_MAJOR_VERSION: '3.12'
-  PYTHON_VERSION: '3.12.6'
+  PYTHON_MAJOR_VERSION: '3.11'
+  PYTHON_VERSION: '3.11.10'
 
 jobs:
   windows:
@@ -49,7 +49,9 @@ jobs:
         run: brew install ffmpeg@6
 
       - name: Which ffmpeg
-        run: which ffmpeg
+        run: |
+          man which 
+          which ffmpeg
 
       - name: Install python
         uses: actions/setup-python@v4

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -2,6 +2,10 @@ name: CI/CD
 
 on: [push, workflow_dispatch]
 
+env:
+  PYTHON_MAJOR_VERSION: '3.12'
+  PYTHON_VERSION: '3.12.6'
+
 jobs:
   windows:
     runs-on: windows-latest
@@ -14,7 +18,7 @@ jobs:
       - name: Install python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10.9'
+          python-version: ${{env.PYTHON_VERSION}}
 
       - name: Install dependencies
         run: |
@@ -24,8 +28,8 @@ jobs:
       - name: Create bundle
         run: |
           (gc kl_gui.spec) -replace 'tools/ffmpeg.exe', "${{steps.setup-ffmpeg.ffmpeg-path}}" | Out-File -encoding UTF8 kl_gui.spec
-          (gc kl_gui.spec) -replace 'tools/', 'C:/hostedtoolcache/windows/Python/3.10.9/x64/Lib/site-packages/ultrastar_pitch/binaries/' | Out-File -encoding UTF8 kl_gui.spec
-          (gc kl_gui.spec) -replace '.venv/', 'C:/hostedtoolcache/windows/Python/3.10.9/x64/' | Out-File -encoding UTF8 kl_gui.spec
+          (gc kl_gui.spec) -replace 'tools/', 'C:/hostedtoolcache/windows/Python/$PYTHON_VERSION/x64/Lib/site-packages/ultrastar_pitch/binaries/' | Out-File -encoding UTF8 kl_gui.spec
+          (gc kl_gui.spec) -replace '.venv/', 'C:/hostedtoolcache/windows/Python/$PYTHON_VERSION/x64/' | Out-File -encoding UTF8 kl_gui.spec
           pyinstaller kl_gui.spec
 
       - name: Upload artifacts
@@ -44,10 +48,13 @@ jobs:
       - name: Install ffmpeg
         run: brew install ffmpeg@6
 
+      - name: Which ffmpeg
+        run: which ffmpeg
+
       - name: Install python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10.9'
+          python-version: ${{env.PYTHON_VERSION}}
 
       - name: Install dependencies
         run: |
@@ -55,8 +62,8 @@ jobs:
           test -f "/usr/local/Cellar/ffmpeg/6.1.1_2/bin/ffmpeg" && sudo sed -i '' 's|tools/ffmpeg.exe|/usr/local/Cellar/ffmpeg/6.1.1_2/bin/ffmpeg|' kl_gui.spec
           test -f "/usr/local/Cellar/ffmpeg/6.1.1_3/bin/ffmpeg" && sudo sed -i '' 's|tools/ffmpeg.exe|/usr/local/Cellar/ffmpeg/6.1.1_3/bin/ffmpeg|' kl_gui.spec
 
-          sudo sed -i '' 's|tools/|/Users/runner/hostedtoolcache/Python/3.10.9/x64/lib/python3.10/site-packages/ultrastar_pitch/binaries/|' kl_gui.spec
-          sudo sed -i '' 's|.venv/lib/|/Users/runner/hostedtoolcache/Python/3.10.9/x64/lib/python3.10/|' kl_gui.spec
+          sudo sed -i '' 's|tools/|/Users/runner/hostedtoolcache/Python/$PYTHON_VERSION/x64/lib/python$PYTHON_MAJOR_VERSION/site-packages/ultrastar_pitch/binaries/|' kl_gui.spec
+          sudo sed -i '' 's|.venv/lib/|/Users/runner/hostedtoolcache/Python/$PYTHON_VERSION/x64/lib/python$PYTHON_MAJOR_VERSION/|' kl_gui.spec
           
           sudo sed -i '' 's|PyQt5-Qt5|PyQt5|' requirements.txt
           python -m pip install -r requirements.txt
@@ -84,13 +91,13 @@ jobs:
       - name: Install python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10.9'
+          python-version: ${{env.PYTHON_VERSION}}
 
       - name: Install dependencies
         run: |
           sudo sed -i 's|tools/ffmpeg.exe|/usr/bin/ffmpeg|' kl_gui.spec
-          sudo sed -i 's|tools/|/opt/hostedtoolcache/Python/3.10.9/x64/lib/python3.10/site-packages/ultrastar_pitch/binaries/|' kl_gui.spec
-          sudo sed -i 's|.venv/lib/|/opt/hostedtoolcache/Python/3.10.9/x64/lib/python3.10/|' kl_gui.spec
+          sudo sed -i 's|tools/|/opt/hostedtoolcache/Python/$PYTHON_VERSION/x64/lib/python$PYTHON_MAJOR_VERSION/site-packages/ultrastar_pitch/binaries/|' kl_gui.spec
+          sudo sed -i 's|.venv/lib/|/opt/hostedtoolcache/Python/$PYTHON_VERSION/x64/lib/python$PYTHON_MAJOR_VERSION/|' kl_gui.spec
           
           sudo sed -i 's|PyQt5-Qt5|PyQt5|' requirements.txt
           python -m pip install -r requirements.txt

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -29,7 +29,13 @@ jobs:
         run: |
           echo "${{steps.setup-ffmpeg.outputs.ffmpeg-path}}"
           echo "should have been displayed above"
-          (gc kl_gui.spec) -replace 'tools/ffmpeg.exe', "${{steps.setup-ffmpeg.outputs.ffmpeg-path}}" | Out-File -encoding UTF8 kl_gui.spec
+          
+          $enc = [System.Text.Encoding]::UTF8
+          $bytes = $enc.GetBytes("${{steps.setup-ffmpeg.outputs.ffmpeg-path}}")
+          $txt = $enc.GetString($bytes)
+          echo $txt
+          
+          (gc kl_gui.spec) -replace 'tools/ffmpeg.exe', "$txt" | Out-File -encoding UTF8 kl_gui.spec
           (gc kl_gui.spec) -replace 'tools/', "C:/hostedtoolcache/windows/Python/${{env.PYTHON_VERSION}}/x64/Lib/site-packages/ultrastar_pitch/binaries/" | Out-File -encoding UTF8 kl_gui.spec
           (gc kl_gui.spec) -replace '.venv/', "C:/hostedtoolcache/windows/Python/${{env.PYTHON_VERSION}}/x64/" | Out-File -encoding UTF8 kl_gui.spec
           pyinstaller kl_gui.spec
@@ -60,8 +66,10 @@ jobs:
 
       - name: Install dependencies
         run: |
-          FFPATH=$(brew info ffmpeg | python -c "import sys;for line in sys.argv: if '/opt/homebrew' in line: print(line.split()[0])")
+          brew info ffmpeg >> ./temp
+          FFPATH=$(python -c "with open('temp', 'r') as f: for line in f: if '/opt/homebrew' in line: print(line.split()[0])")
           echo $FFPATH
+          rm ./temp
           sudo sed -i '' "s|tools/ffmpeg.exe|$FFPATH/bin/ffmpeg|" kl_gui.spec
 
           sudo sed -i '' 's|tools/|/Users/runner/hostedtoolcache/Python/${{env.PYTHON_VERSION}}/x64/lib/python${{env.PYTHON_MAJOR_VERSION}}/site-packages/ultrastar_pitch/binaries/|' kl_gui.spec

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -38,6 +38,9 @@ jobs:
           echo ((gc kl_gui.spec) -replace 'tools/ffmpeg.exe', "${{steps.setup-ffmpeg.outputs.ffmpeg-path}}")
           
           (gc kl_gui.spec) -replace 'tools/ffmpeg.exe', '${{steps.setup-ffmpeg.outputs.ffmpeg-path}}' | Out-File -encoding UTF8 kl_gui.spec
+          
+          echo "-------"
+          echo gc kl_gui.spec)
           (gc kl_gui.spec) -replace 'tools/', "C:/hostedtoolcache/windows/Python/${{env.PYTHON_VERSION}}/x64/Lib/site-packages/ultrastar_pitch/binaries/" | Out-File -encoding UTF8 kl_gui.spec
           (gc kl_gui.spec) -replace '.venv/', "C:/hostedtoolcache/windows/Python/${{env.PYTHON_VERSION}}/x64/" | Out-File -encoding UTF8 kl_gui.spec
           pyinstaller kl_gui.spec
@@ -68,7 +71,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          FFPATH=$(brew info ffmpeg | python -c "import sys;[print(line.split()[0]) for line in sys.argv if '/opt/homebrew' in line]")
+          FFPATH=$(brew info ffmpeg | python -c "import sys;[sys.stdout.write(line.split()[0]) for line in sys.stdin if '/opt/homebrew' in line]")
           echo $FFPATH
           sudo sed -i '' "s|tools/ffmpeg.exe|$FFPATH/bin/ffmpeg|" kl_gui.spec
 

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -37,7 +37,7 @@ jobs:
           
           echo ((gc kl_gui.spec) -replace 'tools/ffmpeg.exe', "${{steps.setup-ffmpeg.outputs.ffmpeg-path}}")
           
-          (gc kl_gui.spec) -replace 'tools/ffmpeg.exe', '${{steps.setup-ffmpeg.outputs.ffmpeg-path}}' | Out-File -encoding UTF8 kl_gui.spec
+          (gc kl_gui.spec) -replace 'tools/ffmpeg.exe', ('${{steps.setup-ffmpeg.outputs.ffmpeg-path}}' -replace '\\', '/') | Out-File -encoding UTF8 kl_gui.spec
           
           echo "-------"
           echo (gc kl_gui.spec)
@@ -65,9 +65,6 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{env.PYTHON_VERSION}}
-          #test -f "/usr/local/Cellar/ffmpeg/6.0_2/bin/ffmpeg" && sudo sed -i '' 's|tools/ffmpeg.exe|/usr/local/Cellar/ffmpeg/6.0_2/bin/ffmpeg|' kl_gui.spec
-          #test -f "/usr/local/Cellar/ffmpeg/6.1.1_2/bin/ffmpeg" && sudo sed -i '' 's|tools/ffmpeg.exe|/usr/local/Cellar/ffmpeg/6.1.1_2/bin/ffmpeg|' kl_gui.spec
-          #test -f "/usr/local/Cellar/ffmpeg/6.1.1_3/bin/ffmpeg" && sudo sed -i '' 's|tools/ffmpeg.exe|/usr/local/Cellar/ffmpeg/6.1.1_3/bin/ffmpeg|' kl_gui.spec
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -27,6 +27,8 @@ jobs:
 
       - name: Create bundle
         run: |
+          echo "${{steps.setup-ffmpeg.ffmpeg-path}}"
+          echo "should have been displayed above"
           (gc kl_gui.spec) -replace 'tools/ffmpeg.exe', "${{steps.setup-ffmpeg.ffmpeg-path}}" | Out-File -encoding UTF8 kl_gui.spec
           (gc kl_gui.spec) -replace 'tools/', "C:/hostedtoolcache/windows/Python/${{env.PYTHON_VERSION}}/x64/Lib/site-packages/ultrastar_pitch/binaries/" | Out-File -encoding UTF8 kl_gui.spec
           (gc kl_gui.spec) -replace '.venv/', "C:/hostedtoolcache/windows/Python/${{env.PYTHON_VERSION}}/x64/" | Out-File -encoding UTF8 kl_gui.spec
@@ -45,10 +47,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-#      - name: Install ffmpeg
-#        run: brew install ffmpeg@6
-      - uses: FedericoCarboni/setup-ffmpeg@v3
-        id: setup-ffmpeg
+      - name: Install ffmpeg
+        run: brew install ffmpeg@6
+
+      - name: find ffmpeg
+        run: brew info ffmpeg
 
       - name: Install python
         uses: actions/setup-python@v4

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -50,7 +50,8 @@ jobs:
 
       - name: Which ffmpeg
         run: |
-          which ls 
+          which ls
+          echo $PATH
           which ffmpeg
 
       - name: Install python

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -35,7 +35,7 @@ jobs:
           $txt = $enc.GetString($bytes)
           echo $txt
           
-          (gc kl_gui.spec) -replace 'tools/ffmpeg.exe', "$txt" | Out-File -encoding UTF8 kl_gui.spec
+          (gc kl_gui.spec) -replace 'tools/ffmpeg.exe', $txt | Out-File -encoding UTF8 kl_gui.spec
           (gc kl_gui.spec) -replace 'tools/', "C:/hostedtoolcache/windows/Python/${{env.PYTHON_VERSION}}/x64/Lib/site-packages/ultrastar_pitch/binaries/" | Out-File -encoding UTF8 kl_gui.spec
           (gc kl_gui.spec) -replace '.venv/', "C:/hostedtoolcache/windows/Python/${{env.PYTHON_VERSION}}/x64/" | Out-File -encoding UTF8 kl_gui.spec
           pyinstaller kl_gui.spec
@@ -66,10 +66,10 @@ jobs:
 
       - name: Install dependencies
         run: |
-          brew info ffmpeg >> ./temp
-          FFPATH=$(python -c "with open('temp', 'r') as f: for line in f: if '/opt/homebrew' in line: print(line.split()[0])")
+          echo "import sys\n[print(line.split()[0]) for line in sys.argv if '/opt/homebrew' in line]" >> temp.py
+          FFPATH=$(brew info ffmpeg | python ./temp.py)
           echo $FFPATH
-          rm ./temp
+          rm ./temp.py
           sudo sed -i '' "s|tools/ffmpeg.exe|$FFPATH/bin/ffmpeg|" kl_gui.spec
 
           sudo sed -i '' 's|tools/|/Users/runner/hostedtoolcache/Python/${{env.PYTHON_VERSION}}/x64/lib/python${{env.PYTHON_MAJOR_VERSION}}/site-packages/ultrastar_pitch/binaries/|' kl_gui.spec

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -35,7 +35,9 @@ jobs:
           $txt = $enc.GetString($bytes)
           echo $txt
           
-          (gc kl_gui.spec) -replace 'tools/ffmpeg.exe', $txt | Out-File -encoding UTF8 kl_gui.spec
+          echo ((gc kl_gui.spec) -replace 'tools/ffmpeg.exe', "${{steps.setup-ffmpeg.outputs.ffmpeg-path}}")
+          
+          (gc kl_gui.spec) -replace 'tools/ffmpeg.exe', '${{steps.setup-ffmpeg.outputs.ffmpeg-path}}' | Out-File -encoding UTF8 kl_gui.spec
           (gc kl_gui.spec) -replace 'tools/', "C:/hostedtoolcache/windows/Python/${{env.PYTHON_VERSION}}/x64/Lib/site-packages/ultrastar_pitch/binaries/" | Out-File -encoding UTF8 kl_gui.spec
           (gc kl_gui.spec) -replace '.venv/', "C:/hostedtoolcache/windows/Python/${{env.PYTHON_VERSION}}/x64/" | Out-File -encoding UTF8 kl_gui.spec
           pyinstaller kl_gui.spec
@@ -66,10 +68,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          echo "import sys\n[print(line.split()[0]) for line in sys.argv if '/opt/homebrew' in line]" >> temp.py
-          FFPATH=$(brew info ffmpeg | python ./temp.py)
+          FFPATH=$(brew info ffmpeg | python -c "import sys;[print(line.split()[0]) for line in sys.argv if '/opt/homebrew' in line]")
           echo $FFPATH
-          rm ./temp.py
           sudo sed -i '' "s|tools/ffmpeg.exe|$FFPATH/bin/ffmpeg|" kl_gui.spec
 
           sudo sed -i '' 's|tools/|/Users/runner/hostedtoolcache/Python/${{env.PYTHON_VERSION}}/x64/lib/python${{env.PYTHON_MAJOR_VERSION}}/site-packages/ultrastar_pitch/binaries/|' kl_gui.spec

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -28,8 +28,8 @@ jobs:
       - name: Create bundle
         run: |
           (gc kl_gui.spec) -replace 'tools/ffmpeg.exe', "${{steps.setup-ffmpeg.ffmpeg-path}}" | Out-File -encoding UTF8 kl_gui.spec
-          (gc kl_gui.spec) -replace 'tools/', 'C:/hostedtoolcache/windows/Python/$PYTHON_VERSION/x64/Lib/site-packages/ultrastar_pitch/binaries/' | Out-File -encoding UTF8 kl_gui.spec
-          (gc kl_gui.spec) -replace '.venv/', 'C:/hostedtoolcache/windows/Python/$PYTHON_VERSION/x64/' | Out-File -encoding UTF8 kl_gui.spec
+          (gc kl_gui.spec) -replace 'tools/', 'C:/hostedtoolcache/windows/Python/${{env.PYTHON_VERSION}}/x64/Lib/site-packages/ultrastar_pitch/binaries/' | Out-File -encoding UTF8 kl_gui.spec
+          (gc kl_gui.spec) -replace '.venv/', 'C:/hostedtoolcache/windows/Python/${{env.PYTHON_VERSION}}/x64/' | Out-File -encoding UTF8 kl_gui.spec
           pyinstaller kl_gui.spec
 
       - name: Upload artifacts
@@ -48,12 +48,6 @@ jobs:
       - name: Install ffmpeg
         run: brew install ffmpeg@6
 
-      - name: Which ffmpeg
-        run: |
-          which ls
-          echo $PATH
-          which ffmpeg
-
       - name: Install python
         uses: actions/setup-python@v4
         with:
@@ -65,8 +59,8 @@ jobs:
           test -f "/usr/local/Cellar/ffmpeg/6.1.1_2/bin/ffmpeg" && sudo sed -i '' 's|tools/ffmpeg.exe|/usr/local/Cellar/ffmpeg/6.1.1_2/bin/ffmpeg|' kl_gui.spec
           test -f "/usr/local/Cellar/ffmpeg/6.1.1_3/bin/ffmpeg" && sudo sed -i '' 's|tools/ffmpeg.exe|/usr/local/Cellar/ffmpeg/6.1.1_3/bin/ffmpeg|' kl_gui.spec
 
-          sudo sed -i '' 's|tools/|/Users/runner/hostedtoolcache/Python/$PYTHON_VERSION/x64/lib/python$PYTHON_MAJOR_VERSION/site-packages/ultrastar_pitch/binaries/|' kl_gui.spec
-          sudo sed -i '' 's|.venv/lib/|/Users/runner/hostedtoolcache/Python/$PYTHON_VERSION/x64/lib/python$PYTHON_MAJOR_VERSION/|' kl_gui.spec
+          sudo sed -i '' 's|tools/|/Users/runner/hostedtoolcache/Python/${{env.PYTHON_VERSION}}/x64/lib/python${{env.PYTHON_MAJOR_VERSION}}/site-packages/ultrastar_pitch/binaries/|' kl_gui.spec
+          sudo sed -i '' 's|.venv/lib/|/Users/runner/hostedtoolcache/Python/${{env.PYTHON_VERSION}}/x64/lib/python${{env.PYTHON_MAJOR_VERSION}}/|' kl_gui.spec
           
           sudo sed -i '' 's|PyQt5-Qt5|PyQt5|' requirements.txt
           python -m pip install -r requirements.txt
@@ -99,8 +93,8 @@ jobs:
       - name: Install dependencies
         run: |
           sudo sed -i 's|tools/ffmpeg.exe|/usr/bin/ffmpeg|' kl_gui.spec
-          sudo sed -i 's|tools/|/opt/hostedtoolcache/Python/$PYTHON_VERSION/x64/lib/python$PYTHON_MAJOR_VERSION/site-packages/ultrastar_pitch/binaries/|' kl_gui.spec
-          sudo sed -i 's|.venv/lib/|/opt/hostedtoolcache/Python/$PYTHON_VERSION/x64/lib/python$PYTHON_MAJOR_VERSION/|' kl_gui.spec
+          sudo sed -i 's|tools/|/opt/hostedtoolcache/Python/${{env.PYTHON_VERSION}}/x64/lib/python${{env.PYTHON_MAJOR_VERSION}}/site-packages/ultrastar_pitch/binaries/|' kl_gui.spec
+          sudo sed -i 's|.venv/lib/|/opt/hostedtoolcache/Python/${{env.PYTHON_VERSION}}/x64/lib/python${{env.PYTHON_MAJOR_VERSION}}/|' kl_gui.spec
           
           sudo sed -i 's|PyQt5-Qt5|PyQt5|' requirements.txt
           python -m pip install -r requirements.txt

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -48,21 +48,21 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install ffmpeg
-        run: brew install ffmpeg@7
-
-      - name: find ffmpeg
-        run: brew info ffmpeg@7
+        run: brew install ffmpeg
 
       - name: Install python
         uses: actions/setup-python@v4
         with:
           python-version: ${{env.PYTHON_VERSION}}
+          #test -f "/usr/local/Cellar/ffmpeg/6.0_2/bin/ffmpeg" && sudo sed -i '' 's|tools/ffmpeg.exe|/usr/local/Cellar/ffmpeg/6.0_2/bin/ffmpeg|' kl_gui.spec
+          #test -f "/usr/local/Cellar/ffmpeg/6.1.1_2/bin/ffmpeg" && sudo sed -i '' 's|tools/ffmpeg.exe|/usr/local/Cellar/ffmpeg/6.1.1_2/bin/ffmpeg|' kl_gui.spec
+          #test -f "/usr/local/Cellar/ffmpeg/6.1.1_3/bin/ffmpeg" && sudo sed -i '' 's|tools/ffmpeg.exe|/usr/local/Cellar/ffmpeg/6.1.1_3/bin/ffmpeg|' kl_gui.spec
 
       - name: Install dependencies
         run: |
-          test -f "/usr/local/Cellar/ffmpeg/6.0_2/bin/ffmpeg" && sudo sed -i '' 's|tools/ffmpeg.exe|/usr/local/Cellar/ffmpeg/6.0_2/bin/ffmpeg|' kl_gui.spec
-          test -f "/usr/local/Cellar/ffmpeg/6.1.1_2/bin/ffmpeg" && sudo sed -i '' 's|tools/ffmpeg.exe|/usr/local/Cellar/ffmpeg/6.1.1_2/bin/ffmpeg|' kl_gui.spec
-          test -f "/usr/local/Cellar/ffmpeg/6.1.1_3/bin/ffmpeg" && sudo sed -i '' 's|tools/ffmpeg.exe|/usr/local/Cellar/ffmpeg/6.1.1_3/bin/ffmpeg|' kl_gui.spec
+          FFPATH=$(brew info ffmpeg | python -c "import sys;for line in sys.argv: if '/opt/homebrew' in line: print(line.split()[0])")
+          echo $FFPATH
+          sudo sed -i '' "s|tools/ffmpeg.exe|$FFPATH/bin/ffmpeg|" kl_gui.spec
 
           sudo sed -i '' 's|tools/|/Users/runner/hostedtoolcache/Python/${{env.PYTHON_VERSION}}/x64/lib/python${{env.PYTHON_MAJOR_VERSION}}/site-packages/ultrastar_pitch/binaries/|' kl_gui.spec
           sudo sed -i '' 's|.venv/lib/|/Users/runner/hostedtoolcache/Python/${{env.PYTHON_VERSION}}/x64/lib/python${{env.PYTHON_MAJOR_VERSION}}/|' kl_gui.spec

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -28,8 +28,8 @@ jobs:
       - name: Create bundle
         run: |
           (gc kl_gui.spec) -replace 'tools/ffmpeg.exe', "${{steps.setup-ffmpeg.ffmpeg-path}}" | Out-File -encoding UTF8 kl_gui.spec
-          (gc kl_gui.spec) -replace 'tools/', 'C:/hostedtoolcache/windows/Python/${{env.PYTHON_VERSION}}/x64/Lib/site-packages/ultrastar_pitch/binaries/' | Out-File -encoding UTF8 kl_gui.spec
-          (gc kl_gui.spec) -replace '.venv/', 'C:/hostedtoolcache/windows/Python/${{env.PYTHON_VERSION}}/x64/' | Out-File -encoding UTF8 kl_gui.spec
+          (gc kl_gui.spec) -replace 'tools/', "C:/hostedtoolcache/windows/Python/${{env.PYTHON_VERSION}}/x64/Lib/site-packages/ultrastar_pitch/binaries/" | Out-File -encoding UTF8 kl_gui.spec
+          (gc kl_gui.spec) -replace '.venv/', "C:/hostedtoolcache/windows/Python/${{env.PYTHON_VERSION}}/x64/" | Out-File -encoding UTF8 kl_gui.spec
           pyinstaller kl_gui.spec
 
       - name: Upload artifacts
@@ -45,8 +45,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Install ffmpeg
-        run: brew install ffmpeg@6
+#      - name: Install ffmpeg
+#        run: brew install ffmpeg@6
+      - uses: FedericoCarboni/setup-ffmpeg@v3
+        id: setup-ffmpeg
 
       - name: Install python
         uses: actions/setup-python@v4

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -4,7 +4,7 @@ on: [push, workflow_dispatch]
 
 env:
   PYTHON_MAJOR_VERSION: '3.11'
-  PYTHON_VERSION: '3.11.10'
+  PYTHON_VERSION: '3.11.9'
 
 jobs:
   windows:
@@ -50,7 +50,7 @@ jobs:
 
       - name: Which ffmpeg
         run: |
-          man which 
+          which ls 
           which ffmpeg
 
       - name: Install python

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -29,7 +29,7 @@ jobs:
           pyinstaller kl_gui.spec
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: windows
           path: ${{ github.workspace }}\dist\*.exe
@@ -65,7 +65,7 @@ jobs:
         run: pyinstaller kl_gui.spec
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: macos
           path: ${{ github.workspace }}/dist/*
@@ -99,7 +99,7 @@ jobs:
         run: pyinstaller kl_gui.spec
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: ubuntu
           path: ${{ github.workspace }}/dist/*

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -27,20 +27,7 @@ jobs:
 
       - name: Create bundle
         run: |
-          echo "${{steps.setup-ffmpeg.outputs.ffmpeg-path}}"
-          echo "should have been displayed above"
-          
-          $enc = [System.Text.Encoding]::UTF8
-          $bytes = $enc.GetBytes("${{steps.setup-ffmpeg.outputs.ffmpeg-path}}")
-          $txt = $enc.GetString($bytes)
-          echo $txt
-          
-          echo ((gc kl_gui.spec) -replace 'tools/ffmpeg.exe', "${{steps.setup-ffmpeg.outputs.ffmpeg-path}}")
-          
           (gc kl_gui.spec) -replace 'tools/ffmpeg.exe', ('${{steps.setup-ffmpeg.outputs.ffmpeg-path}}' -replace '\\', '/') | Out-File -encoding UTF8 kl_gui.spec
-          
-          echo "-------"
-          echo (gc kl_gui.spec)
           (gc kl_gui.spec) -replace 'tools/', "C:/hostedtoolcache/windows/Python/${{env.PYTHON_VERSION}}/x64/Lib/site-packages/ultrastar_pitch/binaries/" | Out-File -encoding UTF8 kl_gui.spec
           (gc kl_gui.spec) -replace '.venv/', "C:/hostedtoolcache/windows/Python/${{env.PYTHON_VERSION}}/x64/" | Out-File -encoding UTF8 kl_gui.spec
           pyinstaller kl_gui.spec
@@ -87,6 +74,7 @@ jobs:
           name: macos
           path: ${{ github.workspace }}/dist/*
           retention-days: 90
+
 
   ubuntu:
     runs-on:   ubuntu-latest

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -40,7 +40,7 @@ jobs:
           (gc kl_gui.spec) -replace 'tools/ffmpeg.exe', '${{steps.setup-ffmpeg.outputs.ffmpeg-path}}' | Out-File -encoding UTF8 kl_gui.spec
           
           echo "-------"
-          echo gc kl_gui.spec)
+          echo (gc kl_gui.spec)
           (gc kl_gui.spec) -replace 'tools/', "C:/hostedtoolcache/windows/Python/${{env.PYTHON_VERSION}}/x64/Lib/site-packages/ultrastar_pitch/binaries/" | Out-File -encoding UTF8 kl_gui.spec
           (gc kl_gui.spec) -replace '.venv/', "C:/hostedtoolcache/windows/Python/${{env.PYTHON_VERSION}}/x64/" | Out-File -encoding UTF8 kl_gui.spec
           pyinstaller kl_gui.spec
@@ -75,8 +75,8 @@ jobs:
           echo $FFPATH
           sudo sed -i '' "s|tools/ffmpeg.exe|$FFPATH/bin/ffmpeg|" kl_gui.spec
 
-          sudo sed -i '' 's|tools/|/Users/runner/hostedtoolcache/Python/${{env.PYTHON_VERSION}}/x64/lib/python${{env.PYTHON_MAJOR_VERSION}}/site-packages/ultrastar_pitch/binaries/|' kl_gui.spec
-          sudo sed -i '' 's|.venv/lib/|/Users/runner/hostedtoolcache/Python/${{env.PYTHON_VERSION}}/x64/lib/python${{env.PYTHON_MAJOR_VERSION}}/|' kl_gui.spec
+          sudo sed -i '' 's|tools/|/Users/runner/hostedtoolcache/Python/${{env.PYTHON_VERSION}}/arm64/lib/python${{env.PYTHON_MAJOR_VERSION}}/site-packages/ultrastar_pitch/binaries/|' kl_gui.spec
+          sudo sed -i '' 's|.venv/lib/|/Users/runner/hostedtoolcache/Python/${{env.PYTHON_VERSION}}/arm64/lib/python${{env.PYTHON_MAJOR_VERSION}}/|' kl_gui.spec
           
           sudo sed -i '' 's|PyQt5-Qt5|PyQt5|' requirements.txt
           python -m pip install -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ass==0.5.2
 requests==2.28.1
 ultrastar-pitch==1.0.1
-PyQt5-Qt5==5.15.2
+PyQt5-Qt5>=5.15.2
 pyinstaller>=5.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ ass==0.5.2
 requests==2.28.1
 ultrastar-pitch==1.0.1
 PyQt5-Qt5>=5.15.2
-pyinstaller>=5.4.1,<6.0.0
+PyQt5>=5.15.2
+pyinstaller>=5.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ ass==0.5.2
 requests==2.28.1
 ultrastar-pitch==1.0.1
 PyQt5-Qt5>=5.15.2
-pyinstaller>=5.4.1
+pyinstaller>=5.4.1,<6.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ ass==0.5.2
 requests==2.28.1
 ultrastar-pitch==1.0.1
 PyQt5-Qt5==5.15.2
-pyinstaller==5.4.1
+pyinstaller>=5.4.1


### PR DESCRIPTION
**Description**

The CI/CD pipeline has been updated (again). It should now be a bit more resilient thanks to the changes, but who knows when another breaking change will be introduced. Changes:

- Update the `upload-artifact` action version to v4 (the previous version was so old that GitHub refused to run it)
- Change Python version to 3.11.9 (the previous version was no longer available on some of the OSs)
- Change pyinstaller and PyQt5 versions (pip couldn't resolve the environment with the new Python version)
- Python version is now specified via a variable at the top of the CI file, which should make it easier to update in the future
- A bit of a hack was introduced to the Windows CI because it stopped working for no reason*
- The MacOS CI now always uses the latest version of ffmpeg and the file location of the installed version is determined programmatically (using `brew info` and some parsing), so it will hopefully just work in the future

*The path to the ffmpeg executable on Windows is determined using the `ffmpeg-path` variable of the `setup-ffmpeg` action. However, some of the backslashes are no longer properly escaped (i.e. '\\') when written to file, so they were being interpreted as characters (i.e. '\f' → '0xc'). This was hacked around by replacing all the backslashes in the path by forward slashes.

**To test**

1. Download the bundle for your OS from the GitHub Actions run associated with this PR
2. Use the bundled KaraLuxer