### PR TITLE
Fix the BPM conversion algorithm

### DIFF
--- a/ultrastar/ultrastar.py
+++ b/ultrastar/ultrastar.py
@@ -140,13 +140,11 @@ class UltrastarSong():
         else:
             notes[start].duration = bpm_multiplier * round(notes[start].duration / bpm_multiplier)
 
-        last_break_idx = False
+        last_break_idx = []
         for i, note in enumerate(notes[start+1:]):
             if note.note_type == '-':
-                last_break_idx = i
+                last_break_idx.append(i+start+1)
                 continue
-            else:
-                last_break_idx = False
 
             for previous_note in notes[start+i::-1]:
                 if previous_note.note_type != '-':
@@ -173,7 +171,9 @@ class UltrastarSong():
                 note.duration = bpm_multiplier * round(note.duration / bpm_multiplier)
 
             if last_break_idx:
-                notes[last_break_idx].start_beat = note.start_beat
+                for idx in last_break_idx:
+                    notes[idx].start_beat = note.start_beat
+                last_break_idx = []
 
     def __str__(self) -> str:
         """Produces a string representation of the song.


### PR DESCRIPTION
Fixes the bug left in #16 which caused the BPM conversion algorithm to place the line breaks incorrectly, often resulting in subtitle lines being cut short or syllables to be incorrectly get moved from one line to another. All of this has now been fixed, and the line breaks are correctly placed at the start of each line.