### PR TITLE
Remove the ENCODING tag

### DIFF
--- a/karaluxer.py
+++ b/karaluxer.py
@@ -573,9 +573,6 @@ class KaraLuxer():
                 The decision function to use when selecting a style to discard. Must be specified if
                 self.overlap_filter_method is "duet" or "style".
         """
-
-        self.ultrastar_song.add_metadata('ENCODING', 'UTF8')
-
         if self.kara_url:
             kara_id = self.kara_url.split('/')[-1]
             kara_data = self._fetch_kara_data(kara_id)


### PR DESCRIPTION
Following discussions in #22, the `#ENCODING` tag is removed here - Vocaluxe does check for it, but it opens files in UTF8 by default, so there are no issues on all non-historic versions.