### PR TITLE
Switch from DUETSINGERP1 to P1

### DIFF
--- a/karaluxer.py
+++ b/karaluxer.py
@@ -332,8 +332,8 @@ class KaraLuxer():
             styles = [style for style in styles if style[0] != selected_style]
 
         # Add metadata tags to the ultrastar file that name the duet sections according to their style.
-        self.ultrastar_song.add_metadata('#DUETSINGERP1', styles[0][0])
-        self.ultrastar_song.add_metadata('#DUETSINGERP2', styles[1][0])
+        self.ultrastar_song.add_metadata('P1', styles[0][0])
+        self.ultrastar_song.add_metadata('P2', styles[1][0])
 
         p1_lines = self._get_lines_in_style(styles[0][0], lines)
         p2_lines = self._get_lines_in_style(styles[1][0], lines)


### PR DESCRIPTION
Following the suggestion from #22, this PR switches from the deprecated `DUETSINGERP1`/`DUETSINGERP2` headers to the ultrastar format-compliant `P1`/`P2`.