### PR TITLE
Use Python tempfile to create the temporary download directory

### DIFF
--- a/karaluxer.py
+++ b/karaluxer.py
@@ -1,6 +1,7 @@
 # Core Karaluxer functionality - CLI interface
 import os
 import shutil
+import tempfile
 from typing import Callable, Dict, Optional, List, Tuple
 
 from pathlib import Path
@@ -589,7 +590,8 @@ class KaraLuxer():
                 self.ultrastar_song.add_metadata('TAGS', kara_data['tags'])
             self.ultrastar_song.add_metadata('VERSION', '1.1.0')
 
-            temporary_folder = Path('tmp')
+            temporary_folder_obj = tempfile.TemporaryDirectory()
+            temporary_folder = Path(temporary_folder_obj.name)
 
             download_directory = temporary_folder.joinpath(kara_id)
             download_directory.mkdir(parents=True, exist_ok=True)
@@ -741,6 +743,7 @@ class KaraLuxer():
 
         if self.kara_url:
             shutil.rmtree(download_directory)
+            temporary_folder_obj.cleanup()
 
         if self.autopitch:
             self._autopitch(song_folder)


### PR DESCRIPTION
Currently, KaraLuxer dumps a "tmp" directory wherever the user downloads a song from kara.moe. This PR does 2 things:

* Uses the builtin Python `tempfile` module to handle putting that folder somewhere else, so that the user doesn't notice it while KaraLuxer is running;
* Makes sure it gets cleaned up once it's done so as to not leave any track of it after.
Currently, the second part does not apply to the base "tmp" directory, only to the download subfolder.