### PR TITLE
Implement use of #AUDIOURL

### DIFF
--- a/karaluxer.py
+++ b/karaluxer.py
@@ -601,6 +601,9 @@ class KaraLuxer():
             if not self.files['audio']:
                 self._fetch_kara_file(kara_data['media_file'], download_directory)
                 media_path = download_directory.joinpath(kara_data['media_file'])
+                self.ultrastar_song.add_metadata(
+                    'AUDIOURL', 'https://kara.moe/downloads/medias/' + urllib.parse.quote(kara_data['media_file'])
+                )
 
                 # Some songs on Kara have an mp3 as the media file. In the case where the media is not in mp3 form, it
                 # will be converted to mp3 using ffmpeg.


### PR DESCRIPTION
Implements the use of the `#AUDIOURL` tag, as discussed in #22. This is set only when using kara.moe and when the audio is not manually set - i.e. when the audio is pulled from the kara.moe. In this case, the tag is set to the kara.moe API URL to the relevant media file.