### PR TITLE
Fix "tule" -> "tuple" typo in type annotation and duplicate parameter

### DIFF
--- a/karaluxer.py
+++ b/karaluxer.py
@@ -879,7 +879,6 @@ def main() -> None:
                                  help='The off-vocal track for the song. This can be either a path to file or a kara.moe URL.')
     argument_parser.add_argument('-vs', '--vocals', type=str,
                                  help='The vocals track for the song. This can be either a path to file or a kara.moe URL.')
-    argument_parser.add_argument('-io', '--ignore_overlaps', action='store_true', help='Ignore overlapping lines.')
     argument_parser.add_argument('-fd', '--force_dialogue',
                                  action='store_true', help='Force use of lines marked "Dialogue".')
     argument_parser.add_argument('-tv', '--tv_sized', action='store_true', help='Mark this song as TV sized.')
@@ -979,3 +978,4 @@ def main() -> None:
 
 if __name__ == '__main__':
     main()
+

--- a/ultrastar/ultrastar.py
+++ b/ultrastar/ultrastar.py
@@ -207,7 +207,7 @@ class UltrastarSong():
         except NameError:
             return note_lines
 
-    def sort_metadata(self) -> Iterator[tule[str, str]]:
+    def sort_metadata(self) -> Iterator[tuple[str, str]]:
         """Sorts the metadata headers in a spefific order and yields the results.
 
         Iterates over the key-value pairs from ``meta_lines`` using a specific 


### PR DESCRIPTION
There was a typo in the signature of the `sort_metadata` function, which was causing KaraLuxer to crash for me. With this PR, I just fixed it to read "tuple" instead of "tule".
I also had to remove the "ignore overlaps" CLI parameter, which due to the addition of the new mutually-exclusive group was duplicated.