### PR TITLE
Fix CLI

### DIFF
--- a/karaluxer.py
+++ b/karaluxer.py
@@ -887,7 +887,7 @@ def main() -> None:
     argument_parser.add_argument('--karaoke-bpm', type=float, default=1500.,
                                  help='The Karaoke BPM, i.e. the BPM that will be used in the karaoke txt file. '
                                       'If not provided, 1500 will be used as default.')
-    argument_parser.add_argument('--song-bpm', type=int, default=0,
+    argument_parser.add_argument('--song-bpm', type=float, default=0,
                                  help='The true Song BPM, i.e. the BPM of the song. This should be different from the '
                                       'Karaoke BPM; Karaoke BPM has to be an integer multiple of the Song BPM. '
                                       'If provided, this is used to calculate the multiple which is used to remove '

--- a/karaluxer.py
+++ b/karaluxer.py
@@ -927,7 +927,7 @@ def main() -> None:
         arguments.audio,
         arguments.off_vocal,
         arguments.vocals,
-        arguments.ignore_overlaps,
+        overlap_filter_method,
         arguments.force_dialogue,
         arguments.tv_sized,
         arguments.autopitch,


### PR DESCRIPTION
Fixes two CLI issues left over from previous PRs:

1. The `overlap_filter_method` variable defined in #27 was not actually being used
2. Changes the `song_bpm` type to float (which it should be)